### PR TITLE
注文ページを作成

### DIFF
--- a/frontend/src/apis/line_foods.js
+++ b/frontend/src/apis/line_foods.js
@@ -29,3 +29,14 @@ export const replaceLineFoods = (params) => {
       throw e;
     });
 };
+
+export const fetchLineFoods = () => {
+  return axios
+    .get(lineFoods)
+    .then((res) => {
+      return res.data;
+    })
+    .catch((e) => {
+      throw e;
+    });
+};

--- a/frontend/src/apis/orders.js
+++ b/frontend/src/apis/orders.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+import { orders } from "../urls/index";
+
+export const postOrders = (params) => {
+  return axios
+    .post(orders, {
+      line_food_ids: params.line_food_ids,
+    })
+    .then((res) => {
+      return res.data;
+    })
+    .catch((e) => console.error(e));
+};

--- a/frontend/src/components/OrderDetailItem.jsx
+++ b/frontend/src/components/OrderDetailItem.jsx
@@ -1,0 +1,55 @@
+import React, { Fragment } from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+// components
+import { LocalMallIcon, QueryBuilderIcon } from "./Icons";
+
+// constants
+import { FONT_SIZE } from "../styled_constants";
+
+const LineWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const AmountText = styled.p`
+  font-size: ${FONT_SIZE.STAND_BODY};
+  font-weight: bold;
+`;
+
+export const OrderDetailItem = ({
+  restaurantId,
+  restaurantName,
+  restaurantFee,
+  timeRequired,
+  foodCount,
+  price,
+}) => (
+  <Fragment>
+    <LineWrapper>
+      <LocalMallIcon />
+      <Link to={`/restaurants/${restaurantId}/foods`}>{restaurantName}</Link>
+    </LineWrapper>
+    <LineWrapper>
+      <QueryBuilderIcon />
+      {timeRequired}分で到着予定
+    </LineWrapper>
+    <LineWrapper>
+      <p>商品数</p>
+      <p>{foodCount}</p>
+    </LineWrapper>
+    <LineWrapper>
+      <p>商品数:{foodCount}</p>
+      <p>¥ {price}</p>
+    </LineWrapper>
+    <LineWrapper>
+      <p>配送料</p>
+      <p>¥ {restaurantFee}</p>
+    </LineWrapper>
+    <LineWrapper>
+      <AmountText>合計</AmountText>
+      <AmountText>¥ {price + restaurantFee}</AmountText>
+    </LineWrapper>
+  </Fragment>
+);

--- a/frontend/src/containers/Orders.jsx
+++ b/frontend/src/containers/Orders.jsx
@@ -1,5 +1,132 @@
-import { Fragment } from "react";
+import { Fragment, useEffect, useReducer } from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+// components
+import { OrderDetailItem } from "../components/OrderDetailItem";
+import { OrderButton } from "../components/Buttons/OrderButton";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+// api
+import { fetchLineFoods } from "../apis/line_foods";
+import { postOrders } from "../apis/orders";
+
+// reducers
+import {
+  initialState,
+  lineFoodsActionTypes,
+  lineFoodsReducer,
+} from "../reducers/lineFoods";
+
+// images
+import MainLogo from "../images/logo.png";
+
+// constants
+import { REQUEST_STATE } from "../constants";
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  padding: 8px 32px;
+`;
+
+const MainLogoImage = styled.img`
+  height: 90px;
+`;
+
+const OrderListWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const OrderItemWrapper = styled.div`
+  margin-bottom: 50px;
+`;
 
 export const Orders = () => {
-  return <Fragment>注文画面</Fragment>;
+  const [state, dispatch] = useReducer(lineFoodsReducer, initialState);
+  useEffect(() => {
+    dispatch({ type: lineFoodsActionTypes.FETCHING });
+    fetchLineFoods()
+      .then((data) =>
+        dispatch({
+          type: lineFoodsActionTypes.FETCH_SUCCESS,
+          payload: {
+            lineFoodsSummary: data,
+          },
+        })
+      )
+      .catch((e) => console.error(e));
+  }, []);
+
+  const postLineFoods = () => {
+    dispatch({ type: lineFoodsActionTypes.POSTING });
+    postOrders({
+      line_food_ids: state.lineFoodsSummary.line_food_ids,
+    }).then(() => {
+      dispatch({ type: lineFoodsActionTypes.POST_SUCCESS });
+      window.location.reload();
+    });
+  };
+
+  const orderButtonLabel = () => {
+    switch (state.postState) {
+      case REQUEST_STATE.LOADING:
+        return "注文中...";
+      case REQUEST_STATE.OK:
+        return "注文が完了しました！";
+      default:
+        return "注文を確定する";
+    }
+  };
+
+  return (
+    <Fragment>
+      <HeaderWrapper>
+        <Link to="/restaurants">
+          <MainLogoImage src={MainLogo} alt="main logo" />
+        </Link>
+      </HeaderWrapper>
+      <OrderListWrapper>
+        <div>
+          <OrderItemWrapper>
+            {
+              // APIローディング中はくるくる回るローディングコンポーネントを表示
+              state.fetchState === REQUEST_STATE.LOADING ? (
+                <CircularProgress />
+              ) : (
+                state.lineFoodsSummary && (
+                  <OrderDetailItem
+                    restaurantFee={state.lineFoodsSummary.restaurant.fee}
+                    restaurantName={state.lineFoodsSummary.restaurant.name}
+                    restaurantId={state.lineFoodsSummary.restaurant.id}
+                    timeRequired={
+                      state.lineFoodsSummary.restaurant.time_required
+                    }
+                    foodCount={state.lineFoodsSummary.count}
+                    price={state.lineFoodsSummary.amount}
+                  />
+                )
+              )
+            }
+          </OrderItemWrapper>
+          <div>
+            {state.fetchState === REQUEST_STATE.OK && state.lineFoodsSummary && (
+              <OrderButton
+                onClick={() => postLineFoods()}
+                disabled={
+                  state.postState === REQUEST_STATE.LOADING ||
+                  state.postState === REQUEST_STATE.OK
+                }
+              >
+                {orderButtonLabel()}
+              </OrderButton>
+            )}
+            {state.fetchState === REQUEST_STATE.OK &&
+              !state.lineFoodsSummary && <p>注文予定の商品はありません。</p>}
+          </div>
+        </div>
+      </OrderListWrapper>
+    </Fragment>
+  );
 };

--- a/frontend/src/reducers/lineFoods.js
+++ b/frontend/src/reducers/lineFoods.js
@@ -1,0 +1,53 @@
+import axios from "axios";
+import { REQUEST_STATE } from "../constants";
+import { lineFoods } from "../urls/index";
+
+export const initialState = {
+  fetchState: REQUEST_STATE.INITIAL, // 取得状況
+  postState: REQUEST_STATE.INITIAL, // 登録状況
+  lineFoodsSummary: null, // 仮注文データ
+};
+
+export const lineFoodsActionTypes = {
+  FETCHING: "FETCHING",
+  FETCH_SUCCESS: "FETCH_SUCCESS",
+  POSTING: "POSTING",
+  POST_SUCCESS: "POST_SUCCESS",
+};
+export const fetchLineFoods = () => {
+  return axios
+    .get(lineFoods)
+    .then((res) => {
+      return res.data;
+    })
+    .catch((e) => {
+      throw e;
+    });
+};
+
+export const lineFoodsReducer = (state, action) => {
+  switch (action.type) {
+    case lineFoodsActionTypes.FETCHING:
+      return {
+        ...state,
+        fetchState: REQUEST_STATE.LOADING,
+      };
+    case lineFoodsActionTypes.FETCH_SUCCESS:
+      return {
+        fetchState: REQUEST_STATE.OK,
+        lineFoodsSummary: action.payload.lineFoodsSummary,
+      };
+    case lineFoodsActionTypes.POSTING:
+      return {
+        ...state,
+        postState: REQUEST_STATE.LOADING,
+      };
+    case lineFoodsActionTypes.POST_SUCCESS:
+      return {
+        ...state,
+        postState: REQUEST_STATE.OK,
+      };
+    default:
+      throw new Error();
+  }
+};


### PR DESCRIPTION
### 実現したこと
- 仮注文詳細のAPIを叩く
- 注文を登録する

### 実装したこと
1. API関数を実装　`line_foods.js`
2. `line_foods.js`で作成したAPIの関数をOrders.jsxから呼ぶ
3. 仮注文取得状況と仮注文から注文を登録する動線のreducerを定義　`lineFoods.js`
4. `Orders.jsx`にreducerを追加
5. 注文を登録する為、`apis/orders.js`を実装
6. `Order.jsx`に`apis/orders.js`で作成したコンポーネントを取り組む
7. レイアウト・コンポーネントを定義。`components/OrderDetailItem.jsx`
8. `Orders.jsx`スタイル追加
